### PR TITLE
get rid of learn_adj flag

### DIFF
--- a/models_gcn.py
+++ b/models_gcn.py
@@ -29,9 +29,9 @@ class GCN(torch.nn.Module):
         else:
             from torch_geometric.nn import GCNConv
         self.convs = nn.ModuleList([])
-        self.convs.append(GCNConv(nfeat, nhid, learn_adj=learn_adj))
+        self.convs.append(GCNConv(nfeat, nhid))
         for _ in range(nconvs-1):
-            self.convs.append(GCNConv(nhid, nhid, learn_adj=learn_adj))
+            self.convs.append(GCNConv(nhid, nhid))
 
         self.norms = nn.ModuleList([])
         for _ in range(nconvs):


### PR DESCRIPTION
*Issue #, if available:*

python3.8/site-packages/torch_geometric/nn/conv/gcn_conv.py", line 126, in __init__
    super(GCNConv, self).__init__(**kwargs)
TypeError: __init__() got an unexpected keyword argument 'learn_adj'

*Description of changes:*

Eliminating the keyword which is not needed in models_gcn.py

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
